### PR TITLE
Fixes deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('qbil_open_exchange_rate');
 


### PR DESCRIPTION
```
Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "Qbil\OpenExchangeRatesBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.
```